### PR TITLE
Add lispyville-change to evil-change-commands.

### DIFF
--- a/lispyville.el
+++ b/lispyville.el
@@ -125,6 +125,10 @@ to a non-nil value."
   (add-to-list 'evil-surround-operator-alist '(lispyville-change . change))
   (add-to-list 'evil-surround-operator-alist '(lispyville-delete . delete)))
 
+;; https://github.com/noctuid/lispyville/pull/26
+(when (boundp 'evil-change-commands)
+  (add-to-list 'evil-change-commands #'lispyville-change))
+
 ;;;###autoload
 (define-minor-mode lispyville-mode
     "A minor mode for integrating evil with lispy."


### PR DESCRIPTION
Recently, I 'fixed a bug' that impacts all functions that wrap or replace `evil-change`.

Essentially all wrapper functions would exhibit the wrong behavior for `cw`:
`o|ne two` would become `o|two` instead of `o| two`, as it does in vim.

Since your `lispyville-change` function wraps and replaces `evil-change` I made a PR to apply this change to your functions (by adding your function to the exception list, `evil-change-functions`). 

You can go to https://github.com/emacs-evil/evil/issues/916 for more background on this issue (it affects evil-cleverparens and evil-smartparens as well). 

Unfortunately, I could not write tests for this, since I couldn't get tests running on my computer. You could try copying these tests though: https://github.com/expez/evil-smartparens/blob/master/tests/evil-smartparens-tests.el#L358-L363

Please let me know if you find any issues after this commit, and I'll try to fix it up.

