### PR TITLE
Don't use backward-up-list in lispyville-prettify

### DIFF
--- a/lispyville.el
+++ b/lispyville.el
@@ -645,7 +645,7 @@ ARG has the same effect."
   (interactive "<r>")
   (let ((orig-pos (point)))
     (evil-exit-visual-state)
-    (ignore-errors (backward-up-list))
+    (ignore-errors (lispyville-backward-up-list))
     (while (and (ignore-errors (lispyville--forward-list))
                 (<= (save-excursion
                       (backward-list))


### PR DESCRIPTION
backward-up-list without optional args has unexpected behavior in strings.