### PR TITLE
Safe versions of evil-join and comment-or-uncomment

### DIFF
--- a/README.org
+++ b/README.org
@@ -254,13 +254,33 @@ The bindings follow vim/evil-commentary defaults as shown below:
 | key   | command                                |
 |-------+----------------------------------------|
 | =gc=  | ~lispyville-comment-or-uncomment~      |
+| =gy=  | ~lispyville-comment-and-clone-dwim~    |
 | =s-/= | ~lispyville-comment-or-uncomment-line~ |
 
 If you prefer evil-nerd-commenter style bindings, add the following to your configuration, where =,= is the evil leader key:
 #+begin_src emacs-lisp
 (evil-define-key 'motion lispyville-mode-map
   ",,"  #'lispyville-comment-or-uncomment
+  ",."  #'lispyville-comment-and-clone-dwim
   ",ci" #'lispyville-comment-or-uncomment-line)
+#+end_src
+
+The safe comment-and-clone operator operates only on the rightmost balanced region by default. If the region is selected visually, it operates separately on all balanced subregions.
+#+begin_src emacs-lisp
+;; initial state (cursor on first line)
+(foo (bar) (baz|
+            (quux)))
+
+;; "gyy"
+(foo (bar) (;; baz
+            baz
+            (quux)))
+
+;; with visual line selection: "Vgy"
+(;; foo (bar)
+ foo (bar) (;; baz
+            baz
+            (quux)))
 #+end_src
 
 ** Slurp/Barf Key Themes

--- a/README.org
+++ b/README.org
@@ -214,6 +214,22 @@ The corresponding symbol is =additional-motions= or =additional-movement=. The d
 
 There is also the unbound ~lispyville-beginning-of-next-defun~.
 
+** Commentary Key Theme
+The corresponding symbol is  =commentary=. The default state is normal state (inherited in visual state).
+The bindings follow vim/evil-commentary defaults as shown below:
+
+| key   | command                                |
+|-------+----------------------------------------|
+| =gc=  | ~lispyville-comment-or-uncomment~      |
+| =s-/= | ~lispyville-comment-or-uncomment-line~ |
+
+If you prefer evil-nerd-commenter style bindings, add the following to your configuration, where =,= is the evil leader key:
+#+begin_src emacs-lisp
+(evil-define-key 'motion lispyville-mode-map
+  ",,"  #'lispyville-comment-or-uncomment
+  ",ci" #'lispyville-comment-or-uncomment-line)
+#+end_src
+
 ** Slurp/Barf Key Themes
 Two key themes are provided for slurping and barfing keybindings. The default state for both is normal. Note that the commands in both key themes work with digit arguments. A positive argument will barf or slurp that many times like in cleverparens. Additionally, for the slurp commands, an argument of =-1= will slurp to the end of the line where the sexp after the closing paren ends, and an argument of =0= will slurp as far as possible. See the documentation for [[http://oremacs.com/lispy/#lispy-slurp][lispy-slurp]] for more information. Also see [[https://github.com/noctuid/lispyville#more-fluid-transitioning-between-normal-state-and-special][here]] for some extra information on automatically entering special after executing these commands.
 

--- a/README.org
+++ b/README.org
@@ -105,6 +105,39 @@ Like with cleverparens, =dd= will bring closing delimiters that are on a line by
 | =[remap evil-delete-backward-char]= | ~lispyville-delete-char-or-splice-backwards~ |
 | =[remap evil-substitute]=           | ~lispyville-substitute~                      |
 | =[remap evil-change-whole-line]=    | ~lispyville-change-whole-line~               |
+| =[remap evil-join]=                 | ~lispyville-join~                            |
+
+In particular, =J= implements a safe version of the evil-join operator, which preserves structure by always placing uncommented regions to the left of line comments, avoiding the scenario of an unbalanced line being joined to the inline comment above it.
+
+#+begin_src emacs-lisp
+;; before (cursor at |)
+|(foo  ; bar
+  baz)
+
+;; after "J":
+(foo| baz) ; bar
+#+end_src
+
+To "slurp"  following line(s) into the commented region in the usual manner, first explicitly comment them out with =lispyville-comment-or-uncomment=, which moves unbalanced delimiters out of the way (refer to the =commentary= theme).
+=lispyville-join= will then splice the comments together, removing any intermediate whitespace and comment syntax.
+
+#+begin_src emacs-lisp
+;; initial state (cursor at |)
+(foo  ; bar
+ |quux)
+
+;; "gcc"
+(foo  ; bar
+ |;; quux
+ )
+
+;; "kJ"
+(foo  ; bar| quux
+ )
+
+;; "J"
+(foo)|  ; bar quux
+#+end_src
 
 ** C-w Key Theme
 The corresponding symbol is =c-w=. There are no default states; any state where ~evil-delete-backward-word~ is bound will be affected. This is the safe version of ~evil-delete-backward-word~. It will act as ~lispy-delete-backward~ after delimiters (and delete everything within the delimiters).
@@ -302,7 +335,7 @@ The corresponding symbol is =additional-wrap=. The default state is normal state
 | =M-[= | ~lispyville-wrap-brackets~ |
 | =M-{= | ~lispyville-wrap-braces~   |
 
-These are equivalents of ~lisp-wrap-round~, ~lispy-wrap-brackets~, and ~lispy-wrap-braces~. By default, they will wrap the sexp at the point. With a positive count, they will wrap that number of sexps. With a count of 0, they will wrap as far as possible. With a negative count, they will wrap to the sexp at the end of the line (e.g. =|foo bar= to =(|foo bar)=). If you would prefer this behavior by default, you can bind =(= to =lispy-parens-auto-wrap= in insert state (e.g. =(define-key lispy-mode-map-lispy "(" 'lispy-parens-auto-wrap)=). Also, if you would prefer to use something more generic, you can try the [[#wrap-key-theme][wrap key theme]] which provides corresponding operators instead.
+These are equivalents of ~lispy-wrap-round~, ~lispy-wrap-brackets~, and ~lispy-wrap-braces~. By default, they will wrap the sexp at the point. With a positive count, they will wrap that number of sexps. With a count of 0, they will wrap as far as possible. With a negative count, they will wrap to the sexp at the end of the line (e.g. =|foo bar= to =(|foo bar)=). If you would prefer this behavior by default, you can bind =(= to =lispy-parens-auto-wrap= in insert state (e.g. =(define-key lispy-mode-map-lispy "(" 'lispy-parens-auto-wrap)=). Also, if you would prefer to use something more generic, you can try the [[#wrap-key-theme][wrap key theme]] which provides corresponding operators instead.
 
 Normally, lispy will insert a space after the opening delimiter when wrapping. The lispyville versions will never insert a space in normal state. When in a state in =lispyville-insert-states=, these commands will insert a space when =lispy-insert-space-after-wrap= is non-nil (the default).
 

--- a/README.org
+++ b/README.org
@@ -259,7 +259,7 @@ The bindings follow vim/evil-commentary defaults as shown below:
 
 If you prefer evil-nerd-commenter style bindings, add the following to your configuration, where =,= is the evil leader key:
 #+begin_src emacs-lisp
-(evil-define-key 'motion lispyville-mode-map
+(evil-define-key 'normal lispyville-mode-map
   ",,"  #'lispyville-comment-or-uncomment
   ",."  #'lispyville-comment-and-clone-dwim
   ",ci" #'lispyville-comment-or-uncomment-line)

--- a/lispyville-test.el
+++ b/lispyville-test.el
@@ -64,6 +64,16 @@ character after it is not considered as part of the region."
   (yank)
   (goto-char (point-max)))
 
+(defmacro lispyville-should (body before after)
+  "Simple syntax transformation for readability.
+Body is an unquoted list of commands to run,
+or a string which is automatically wrapped in a list."
+  (declare (indent 1))
+  (when (stringp body)
+    (setq body (list body)))
+  `(should (string= (lispyville-with ,before ,@body)
+                    ,after)))
+
 ;;; Operators
 (ert-deftest lispyville-yank ()
   (should (string= (lispyville-with "(|a)"

--- a/lispyville.el
+++ b/lispyville.el
@@ -2044,7 +2044,7 @@ When THEME is not given, `lispville-key-theme' will be used instead."
            "(" #'lispyville-backward-up-list
            ")" #'lispyville-up-list))
         (commentary
-         (or states (setq states 'motion))
+         (or states (setq states 'normal))
          (lispyville--define-key states
            "gc" #'lispyville-comment-or-uncomment
            "gy" #'lispyville-comment-and-clone-dwim


### PR DESCRIPTION
Here are two evil operators I've written that make regular commenting and joining operations behave in a way that preserves balanced lisp structure, like the rest of lispyville. :)
These gifs should do a good job of explaining what they do:
![join-operator](https://user-images.githubusercontent.com/22216124/48501862-31dc2d00-e879-11e8-8c89-867a85edef36.gif)
![comment-or-uncomment-operator](https://user-images.githubusercontent.com/22216124/48501859-30126980-e879-11e8-972b-fa6b8d57db0d.gif)


I realise there should be proper ERT tests written like for the rest of the commands, but still haven't figured out yet how to set them up..
