### PR TITLE
Add lispyville-delete-back-to-indentation

### DIFF
--- a/README.org
+++ b/README.org
@@ -159,6 +159,15 @@ The reason no safe version of ~evil-delete-backward-char-and-join~ is provided i
 |-------------------------------------+------------------------------------|
 | =[remap evil-delete-backward-word]= | ~lispyville-delete-backward-word~  |
 
+** C-u Key Theme
+The corresponding symbol is =c-u=. There are no default states; any state where ~evil-delete-back-to-indentation~ is bound will be affected. This is the safe version of ~evil-delete-back-to-indentation~. It will act as ~lispy-delete-backward~ after delimiters (and delete everything within the delimiters).
+
+The reason no safe version of ~evil-delete-backward-char-and-join~ is provided is because lispy already maps =DEL= to ~lispy-delete-backward~.
+
+| key                                       | command                                 |
+|-------------------------------------------+-----------------------------------------|
+| =[remap evil-delete-back-to-indentation]= | ~lispyville-delete-back-to-indentation~ |
+
 ** Prettify Key Theme
 The corresponding symbol is =prettify=. There are no default states; any state where ~evil-indent~ is bound will be affected. This key theme replaces ~evil-indent~ with an operator equivalent of ~lispy-tab~. In addition to correcting indentation, ~lispy-tab~ will also, for example, remove empty newlines and pull trailing closing delimiters all onto the same line. This operator works by normalizing the current list and all subsequent same-level lists that start within the region.
 

--- a/lispyville-test.el
+++ b/lispyville-test.el
@@ -4,6 +4,7 @@
                              s-operators
                              prettify
                              c-w
+                             c-u
                              additional-movement
                              slurp/barf-cp
                              additional
@@ -363,6 +364,31 @@ or a string which is automatically wrapped in a list."
   (should (string= (lispyville-with "\"a\"|"
                      "i C-w")
                    "|")))
+
+(ert-deftest lispyville-delete-back-to-indentation ()
+  (custom-set-variables '(evil-want-C-u-delete t))
+  (should (string= (lispyville-with "(foo bar\n     foobar|)"
+                     "i C-u")
+                   "(foo bar\n     |)"))
+  (should (string= (lispyville-with "(foo bar\n     |)"
+                     "i C-u")
+                   "(foo bar\n|)"))
+  (should (string= (lispyville-with "(foo bar\n|)"
+                     "i C-u")
+                   "(foo bar|)"))
+  (should (string= (lispyville-with "(foo bar|)"
+                     "i C-u")
+                   "(|)"))
+  (should (string= (lispyville-with "(|a)"
+                     "i C-u")
+                   "|"))
+  (should (string= (lispyville-with "(a)|"
+                     "i C-u")
+                   "|"))
+  (should (string= (lispyville-with "\"a\"|"
+                     "i C-u")
+                   "|"))
+  (custom-set-variables '(evil-want-C-u-delete nil)))
 
 (ert-deftest lispyville-change ()
   ;; linewise; unlike dd, cc should not delete newlines

--- a/lispyville.el
+++ b/lispyville.el
@@ -54,6 +54,9 @@ lispyville has been loaded."
        :tag "Safe version of `evil-delete-backward-word'."
        c-w)
       (const
+       :tag "Safe version of `evil-delete-back-to-indentation'."
+       c-u)
+      (const
        :tag "Alternative to `evil-indent' that acts like `lispy-tab'."
        prettify)
       (const
@@ -564,6 +567,22 @@ This will also act as `lispy-delete-backward' after delimiters."
                                (evil-backward-word-begin)
                                (point))
                              (line-beginning-position))
+                            (point)
+                            'exclusive))))
+
+(evil-define-command lispyville-delete-back-to-indentation ()
+  "Like `evil-delete-back-to-indentation' but will not delete unmatched delimiters.
+This will also act as `lispy-delete-backward' after delimiters."
+  (cond ((bolp)
+         (evil-delete-backward-char-and-join 1))
+        ((lispyville--after-delimiter-p)
+         (lispy-delete-backward 1))
+        (t
+         (lispyville-delete (if (<= (current-column) (current-indentation))
+                                (line-beginning-position)
+                              (save-excursion
+                                (evil-first-non-blank)
+                                (point)))
                             (point)
                             'exclusive))))
 
@@ -1994,6 +2013,10 @@ When THEME is not given, `lispville-key-theme' will be used instead."
          (lispyville--define-key states
            [remap evil-delete-backward-word]
            #'lispyville-delete-backward-word))
+        (c-u
+         (lispyville--define-key states
+           [remap evil-delete-back-to-indentation]
+           #'lispyville-delete-back-to-indentation))
         (prettify
          ;; no states necessary for remaps
          ;; (or states (setq states 'normal))


### PR DESCRIPTION
evil add an `evil-want-C-u-delete` option in https://github.com/emacs-evil/evil/commit/33bb8534f6f8d12ae071cb12a38db6306cb07f87,  this PR implement a safe version of `evil-delete-back-to-indentation`