### PR TITLE
Make lispyville-end-of-defun go past defuns

### DIFF
--- a/lispyville.el
+++ b/lispyville.el
@@ -822,6 +822,10 @@ This won't jump to the beginning of the buffer if there is no paren there."
 (evil-define-motion lispyville-end-of-defun (count)
   "This is the evil motion equivalent of `end-of-defun'.
 This won't jump to the end of the buffer if there is no paren there."
+  (when (<= (- (line-end-position)
+              (point))
+           1)
+    (forward-line))
   (end-of-defun (or count 1))
   (re-search-backward lispy-right nil t)
   (lispyville--maybe-enter-special))

--- a/tests/test-lispyville.el
+++ b/tests/test-lispyville.el
@@ -813,7 +813,12 @@ foo"
     (lispyville-expect-equal
         "(a |b c)"
         "|(a b c)"
-      "M-h")))
+      "M-h"))
+  (it "should act go past defun if called repeatedly"
+    (lispyville-expect-equal
+        "(a b c)(a |b c)"
+        "|(a b c)(a b c)"
+      "M-h M-h")))
 
 (describe "lispyville-end-of-defun"
   (it "should act as `end-of-defun'"
@@ -821,6 +826,11 @@ foo"
         "(a |b c)"
         "(a b c|)"
       "M-l"))
+  (it "should act go past defun if called repeatedly"
+    (lispyville-expect-equal
+        "(a |b c)(a b c)"
+        "(a b c)(a b c|)"
+      "M-l M-l"))
   (it "should go to after the closing delimiter when \
 `lispyville-motions-put-into-special' is non-nil"
     (let ((lispyville-motions-put-into-special t))


### PR DESCRIPTION
`lispyville-end-of-defun` doesn't go to the next defun when point is
already at the end of a defun, whereas `lispyville-beginning-of-defun`
does. This commit fixes this inconsistency by matching
`lispyville-end-of-defun`'s behaviour with `lispyville-beginning-of-defun`.